### PR TITLE
only hit flickr api on initial page load

### DIFF
--- a/app/assets/javascripts/random_background.js.coffee
+++ b/app/assets/javascripts/random_background.js.coffee
@@ -1,15 +1,24 @@
+photos = null
+
 getRandomImage = ->
-  url = "http://api.flickr.com/services/rest/?format=json&sort=interestingness-desc&method=flickr.photos.search&tags=nature&tag_mode=all&api_key=#{flickrApiKey}"
-  $.getScript url
+  if photos?
+    showRandomImage()
+  else
+    url = "http://api.flickr.com/services/rest/?format=json&sort=interestingness-desc&method=flickr.photos.search&tags=nature&tag_mode=all&api_key=#{flickrApiKey}"
+    $.getScript url
 
 @jsonFlickrApi = (result) ->
   if result.stat == "ok" && result.photos.total?
-    randomIndex = Math.ceil(Math.random() * result.photos.photo.length)
-    photo = result.photos.photo[randomIndex]
+    photos = result.photos
+    showRandomImage()
 
-    url = "http://farm#{photo.farm}.static.flickr.com/#{photo.server}/#{photo.id}_#{photo.secret}_b.jpg"
+showRandomImage = ->
+  randomIndex = Math.ceil(Math.random() * photos.photo.length)
+  photo = photos.photo[randomIndex]
 
-    $('body').css('background-image', "url(#{url})")
+  url = "http://farm#{photo.farm}.static.flickr.com/#{photo.server}/#{photo.id}_#{photo.secret}_b.jpg"
+
+  $('body').css('background-image', "url(#{url})")
 
 $ ->
   setInterval getRandomImage, 60000


### PR DESCRIPTION
I've updated the random image script to only hit the flickr api on initial load.

These top interesting images change so rarely that doing this per-image swap is unnecessary.
